### PR TITLE
feat: connect customers page to local SQLite

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -87,3 +87,73 @@ body {
   margin-bottom: 0;
   color: #4b5563;
 }
+
+.status {
+  margin-top: 1rem;
+  color: #4b5563;
+}
+
+.status.error {
+  color: #b91c1c;
+}
+
+.customer-form {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  max-width: 520px;
+}
+
+.customer-form label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: #374151;
+}
+
+.customer-form input,
+.customer-form textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  padding: 0.55rem 0.65rem;
+  font: inherit;
+}
+
+.customer-form button {
+  width: fit-content;
+  border: 1px solid #1d4ed8;
+  background: #1d4ed8;
+  color: #ffffff;
+  border-radius: 0.5rem;
+  padding: 0.55rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+.customer-form button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.table-wrap {
+  margin-top: 1rem;
+  overflow-x: auto;
+}
+
+.customers-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.customers-table th,
+.customers-table td {
+  text-align: left;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 0.65rem 0.5rem;
+  font-size: 0.92rem;
+}
+
+.customers-table th {
+  color: #374151;
+  font-weight: 600;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import "./App.css";
+import { initializeDatabase } from "./db";
 import { CustomersPage } from "./pages/customers/CustomersPage";
 import { DashboardPage } from "./pages/dashboard/DashboardPage";
 import { InventoryPage } from "./pages/inventory/InventoryPage";
@@ -25,11 +26,43 @@ const navItems: NavItem[] = [
 
 export default function App() {
   const [activePage, setActivePage] = useState<string>("dashboard");
+  const [dbReady, setDbReady] = useState<boolean>(false);
+  const [dbError, setDbError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const setupDatabase = async () => {
+      try {
+        await initializeDatabase();
+
+        if (mounted) {
+          setDbReady(true);
+          setDbError(null);
+        }
+      } catch (error) {
+        if (mounted) {
+          setDbReady(false);
+          setDbError(
+            error instanceof Error
+              ? error.message
+              : "Failed to initialize database.",
+          );
+        }
+      }
+    };
+
+    void setupDatabase();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   const pageContent = useMemo(() => {
     switch (activePage) {
       case "customers":
-        return <CustomersPage />;
+        return <CustomersPage dbReady={dbReady} dbError={dbError} />;
       case "ledger":
         return <LedgerPage />;
       case "sales":
@@ -44,7 +77,7 @@ export default function App() {
       default:
         return <DashboardPage />;
     }
-  }, [activePage]);
+  }, [activePage, dbError, dbReady]);
 
   return (
     <div className="app-shell">

--- a/src/pages/customers/CustomersPage.tsx
+++ b/src/pages/customers/CustomersPage.tsx
@@ -1,8 +1,190 @@
-export function CustomersPage() {
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import {
+  createCustomer,
+  Customer,
+  getCustomers,
+} from "../../db";
+
+type CustomersPageProps = {
+  dbReady: boolean;
+  dbError: string | null;
+};
+
+type CustomerFormState = {
+  name: string;
+  phone: string;
+  note: string;
+};
+
+const initialFormState: CustomerFormState = {
+  name: "",
+  phone: "",
+  note: "",
+};
+
+function formatCreatedAt(value: string): string {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+}
+
+export function CustomersPage({ dbReady, dbError }: CustomersPageProps) {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [formState, setFormState] = useState<CustomerFormState>(initialFormState);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const loadCustomers = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const rows = await getCustomers();
+      setCustomers(rows);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to load customers.",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!dbReady || dbError) {
+      return;
+    }
+
+    void loadCustomers();
+  }, [dbError, dbReady, loadCustomers]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!formState.name.trim()) {
+      setErrorMessage("Customer name is required.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      await createCustomer({
+        name: formState.name,
+        phone: formState.phone || undefined,
+        note: formState.note || undefined,
+      });
+
+      setFormState(initialFormState);
+      await loadCustomers();
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Failed to create customer.",
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <section className="page">
       <h1>Customers</h1>
-      <p>Customer list and details will be added in upcoming tasks.</p>
+
+      {dbError && <p className="status error">Database error: {dbError}</p>}
+      {!dbError && !dbReady && <p className="status">Initializing database…</p>}
+
+      <form className="customer-form" onSubmit={handleSubmit}>
+        <label>
+          Name *
+          <input
+            type="text"
+            value={formState.name}
+            onChange={(event) =>
+              setFormState((previous) => ({
+                ...previous,
+                name: event.target.value,
+              }))
+            }
+            required
+            disabled={!dbReady || !!dbError || isSubmitting}
+          />
+        </label>
+
+        <label>
+          Phone
+          <input
+            type="text"
+            value={formState.phone}
+            onChange={(event) =>
+              setFormState((previous) => ({
+                ...previous,
+                phone: event.target.value,
+              }))
+            }
+            disabled={!dbReady || !!dbError || isSubmitting}
+          />
+        </label>
+
+        <label>
+          Note
+          <textarea
+            rows={3}
+            value={formState.note}
+            onChange={(event) =>
+              setFormState((previous) => ({
+                ...previous,
+                note: event.target.value,
+              }))
+            }
+            disabled={!dbReady || !!dbError || isSubmitting}
+          />
+        </label>
+
+        <button
+          type="submit"
+          disabled={!dbReady || !!dbError || isSubmitting}
+        >
+          {isSubmitting ? "Saving..." : "Add customer"}
+        </button>
+      </form>
+
+      {errorMessage && <p className="status error">{errorMessage}</p>}
+      {isLoading && <p className="status">Loading customers…</p>}
+
+      {!isLoading && customers.length === 0 && dbReady && !dbError && (
+        <p className="status">No customers yet.</p>
+      )}
+
+      {customers.length > 0 && (
+        <div className="table-wrap">
+          <table className="customers-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Phone</th>
+                <th>Note</th>
+                <th>Created at</th>
+              </tr>
+            </thead>
+            <tbody>
+              {customers.map((customer) => (
+                <tr key={customer.id}>
+                  <td>{customer.name}</td>
+                  <td>{customer.phone || "-"}</td>
+                  <td>{customer.note || "-"}</td>
+                  <td>{formatCreatedAt(customer.created_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a working Customers page backed by the existing local SQLite layer so users can add and view customers offline. 
- Ensure the database is initialized on app startup so pages can safely interact with the DB. 
- Keep UI simple while exposing basic create/list flows and surface loading/error states.

### Description
- Initialize the SQLite schema on app startup by calling `initializeDatabase` from `App.tsx`, with `dbReady` and `dbError` state for pages to react to startup status. 
- Implement `CustomersPage` (`src/pages/customers/CustomersPage.tsx`) using `getCustomers` to load the list and `createCustomer` to add new records, rendering `name`, `phone`, `note`, and `created_at`. 
- Add a simple creation form with required `name` and optional `phone`/`note`, which clears after successful create and reloads the list; includes basic loading and error UI. 
- Add minimal styling in `src/App.css` for the form, table, and status messages; no new dependencies or backend/auth were added.

### Testing
- Ran `npm install` to restore dependencies and it completed successfully. 
- Ran a production build with `npm run build` and it completed successfully (no test suite was present; build verifies TypeScript/JSX compilation and bundling).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f10d22be9c8327935da21209f9c427)