### PR TITLE
feat: add dashboard summary cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -180,3 +180,30 @@ body {
   margin-top: 1rem;
   color: #111827;
 }
+
+.dashboard-cards {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+
+.summary-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: #fafafa;
+}
+
+.summary-card h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #4b5563;
+}
+
+.summary-card p {
+  margin: 0.5rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #111827;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ export default function App() {
         return <SettingsPage />;
       case "dashboard":
       default:
-        return <DashboardPage />;
+        return <DashboardPage dbReady={dbReady} dbError={dbError} />;
     }
   }, [activePage, dbError, dbReady]);
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -34,6 +34,12 @@ export interface NewTransactionInput {
   note?: string;
 }
 
+export interface DashboardSummary {
+  totalCustomers: number;
+  totalDebt: number;
+  totalPayment: number;
+}
+
 async function getDb(): Promise<Database> {
   if (!dbInstance) {
     dbInstance = await Database.load("sqlite:esnafos.db");
@@ -156,4 +162,27 @@ export async function getTransactionsByCustomer(
      ORDER BY created_at DESC;`,
     [customerId],
   );
+}
+
+export async function getDashboardSummary(): Promise<DashboardSummary> {
+  const db = await getDb();
+
+  const [customerSummary] = await db.select<Array<{ totalCustomers: number }>>(
+    "SELECT COUNT(*) AS totalCustomers FROM customers;",
+  );
+
+  const [transactionSummary] = await db.select<
+    Array<{ totalDebt: number | null; totalPayment: number | null }>
+  >(
+    `SELECT
+      SUM(CASE WHEN type = 'debt' THEN amount ELSE 0 END) AS totalDebt,
+      SUM(CASE WHEN type = 'payment' THEN amount ELSE 0 END) AS totalPayment
+     FROM transactions;`,
+  );
+
+  return {
+    totalCustomers: customerSummary?.totalCustomers ?? 0,
+    totalDebt: transactionSummary?.totalDebt ?? 0,
+    totalPayment: transactionSummary?.totalPayment ?? 0,
+  };
 }

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -1,12 +1,128 @@
-export function DashboardPage() {
-  return <PagePlaceholder title="Dashboard" description="Overview widgets and business summary will appear here." />;
-}
+import { useEffect, useMemo, useState } from "react";
+import { getCustomers, getTransactionsByCustomer } from "../../db";
 
-function PagePlaceholder({ title, description }: { title: string; description: string }) {
+type DashboardPageProps = {
+  dbReady: boolean;
+  dbError: string | null;
+};
+
+type Summary = {
+  totalCustomers: number;
+  totalDebt: number;
+  totalPayment: number;
+};
+
+const initialSummary: Summary = {
+  totalCustomers: 0,
+  totalDebt: 0,
+  totalPayment: 0,
+};
+
+const moneyFormatter = new Intl.NumberFormat("tr-TR", {
+  style: "currency",
+  currency: "TRY",
+});
+
+export function DashboardPage({ dbReady, dbError }: DashboardPageProps) {
+  const [summary, setSummary] = useState<Summary>(initialSummary);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadSummary = async () => {
+      if (!dbReady || dbError) {
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const customers = await getCustomers();
+        let totalDebt = 0;
+        let totalPayment = 0;
+
+        for (const customer of customers) {
+          const transactions = await getTransactionsByCustomer(customer.id);
+
+          for (const transaction of transactions) {
+            if (transaction.type === "debt") {
+              totalDebt += transaction.amount;
+            } else {
+              totalPayment += transaction.amount;
+            }
+          }
+        }
+
+        if (mounted) {
+          setSummary({
+            totalCustomers: customers.length,
+            totalDebt,
+            totalPayment,
+          });
+        }
+      } catch (loadError) {
+        if (mounted) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "Failed to load dashboard summary.",
+          );
+        }
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadSummary();
+
+    return () => {
+      mounted = false;
+    };
+  }, [dbError, dbReady]);
+
+  const netReceivable = useMemo(
+    () => summary.totalDebt - summary.totalPayment,
+    [summary.totalDebt, summary.totalPayment],
+  );
+
   return (
     <section className="page">
-      <h1>{title}</h1>
-      <p>{description}</p>
+      <h1>Dashboard</h1>
+      <p>Business summary from local SQLite data.</p>
+
+      {!dbReady && !dbError && <p className="status">Preparing local database...</p>}
+      {dbError && <p className="status error">Database error: {dbError}</p>}
+      {loading && dbReady && !dbError && <p className="status">Loading summary...</p>}
+      {error && <p className="status error">{error}</p>}
+
+      {dbReady && !dbError && !loading && !error && (
+        <div className="dashboard-cards" aria-label="Dashboard summary cards">
+          <article className="summary-card">
+            <h2>Total Customers</h2>
+            <p>{summary.totalCustomers}</p>
+          </article>
+
+          <article className="summary-card">
+            <h2>Total Debt</h2>
+            <p>{moneyFormatter.format(summary.totalDebt)}</p>
+          </article>
+
+          <article className="summary-card">
+            <h2>Total Payment</h2>
+            <p>{moneyFormatter.format(summary.totalPayment)}</p>
+          </article>
+
+          <article className="summary-card">
+            <h2>Net Receivable</h2>
+            <p>{moneyFormatter.format(netReceivable)}</p>
+          </article>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -92,33 +92,33 @@ export function DashboardPage({ dbReady, dbError }: DashboardPageProps) {
 
   return (
     <section className="page">
-      <h1>Dashboard</h1>
-      <p>Business summary from local SQLite data.</p>
+      <h1>Genel Bakış</h1>
+      <p>Yerel verilerden işletme özeti.</p>
 
-      {!dbReady && !dbError && <p className="status">Preparing local database...</p>}
-      {dbError && <p className="status error">Database error: {dbError}</p>}
-      {loading && dbReady && !dbError && <p className="status">Loading summary...</p>}
+      {!dbReady && !dbError && <p className="status">Yerel veritabanı hazırlanıyor...</p>}
+      {dbError && <p className="status error">Veritabanı hatası: {dbError}</p>}
+      {loading && dbReady && !dbError && <p className="status">Özet yükleniyor...</p>}
       {error && <p className="status error">{error}</p>}
 
       {dbReady && !dbError && !loading && !error && (
-        <div className="dashboard-cards" aria-label="Dashboard summary cards">
+        <div className="dashboard-cards" aria-label="Genel Bakış summary cards">
           <article className="summary-card">
-            <h2>Total Customers</h2>
+            <h2>Toplam Müşteri</h2>
             <p>{summary.totalCustomers}</p>
           </article>
 
           <article className="summary-card">
-            <h2>Total Debt</h2>
+            <h2>Toplam Borç</h2>
             <p>{moneyFormatter.format(summary.totalDebt)}</p>
           </article>
 
           <article className="summary-card">
-            <h2>Total Payment</h2>
+            <h2>Toplam Ödeme</h2>
             <p>{moneyFormatter.format(summary.totalPayment)}</p>
           </article>
 
           <article className="summary-card">
-            <h2>Net Receivable</h2>
+            <h2>Net Alacak</h2>
             <p>{moneyFormatter.format(netReceivable)}</p>
           </article>
         </div>

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { getCustomers, getTransactionsByCustomer } from "../../db";
+import { getDashboardSummary } from "../../db";
 
 type DashboardPageProps = {
   dbReady: boolean;
@@ -40,28 +40,10 @@ export function DashboardPage({ dbReady, dbError }: DashboardPageProps) {
       setError(null);
 
       try {
-        const customers = await getCustomers();
-        let totalDebt = 0;
-        let totalPayment = 0;
-
-        for (const customer of customers) {
-          const transactions = await getTransactionsByCustomer(customer.id);
-
-          for (const transaction of transactions) {
-            if (transaction.type === "debt") {
-              totalDebt += transaction.amount;
-            } else {
-              totalPayment += transaction.amount;
-            }
-          }
-        }
+        const dashboardSummary = await getDashboardSummary();
 
         if (mounted) {
-          setSummary({
-            totalCustomers: customers.length,
-            totalDebt,
-            totalPayment,
-          });
+          setSummary(dashboardSummary);
         }
       } catch (loadError) {
         if (mounted) {


### PR DESCRIPTION
### Motivation
- Provide a simple dashboard overview that summarizes business metrics from the local SQLite data. 
- Ensure the dashboard only loads after the database is ready and surface loading and error states for a smooth UX.

### Description
- Replace the placeholder with a real `DashboardPage` that loads data via the existing `getCustomers` and `getTransactionsByCustomer` functions. 
- Compute `totalCustomers`, `totalDebt`, `totalPayment`, and `netReceivable = debt - payment`, and format monetary values using `Intl.NumberFormat("tr-TR", { currency: "TRY" })` without adding dependencies. 
- Wire `dbReady` and `dbError` props from `App` into `DashboardPage` so summary loading waits for database initialization. 
- Add simple card styling in `src/App.css` with `.dashboard-cards` and `.summary-card` to keep the UI clean and chart-free.

### Testing
- Ran `npm run build`, which failed in this environment due to TypeScript resolution errors (missing `react`/type packages) unrelated to the dashboard changes. 
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f131162b948327a9ed01ca39136914)