### PR TITLE
feat: add sales slips and sales history

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -93,6 +93,14 @@ body {
   color: #4b5563;
 }
 
+
+.status.warning {
+  color: #92400e;
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+}
 .status.error {
   color: #b91c1c;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ export default function App() {
       case "ledger":
         return <LedgerPage dbReady={dbReady} dbError={dbError} />;
       case "sales":
-        return <SalesPage />;
+        return <SalesPage dbReady={dbReady} dbError={dbError} />;
       case "orders":
         return <OrdersPage />;
       case "inventory":

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -231,32 +231,39 @@ export async function createSale(input: NewSaleInput): Promise<number> {
 
   const totalAmount = input.quantity * input.unitPrice;
 
-  const saleResult = await db.execute(
-    "INSERT INTO sales (customer_id, payment_type, total_amount, note) VALUES ($1, $2, $3, $4);",
-    [input.customerId ?? null, input.paymentType, totalAmount, input.note ?? null],
-  );
+  await db.execute("BEGIN TRANSACTION;");
 
-  if (saleResult.lastInsertId == null) {
-    throw new Error("Failed to create sale record.");
+  try {
+    const saleResult = await db.execute(
+      "INSERT INTO sales (customer_id, payment_type, total_amount, note) VALUES ($1, $2, $3, $4);",
+      [input.customerId ?? null, input.paymentType, totalAmount, input.note ?? null],
+    );
+
+    if (saleResult.lastInsertId == null) {
+      throw new Error("Failed to create sale record.");
+    }
+
+    const saleId = saleResult.lastInsertId;
+
+    await db.execute(
+      "INSERT INTO sale_items (sale_id, item_name, quantity, unit_price, total_price) VALUES ($1, $2, $3, $4, $5);",
+      [saleId, itemName, input.quantity, input.unitPrice, totalAmount],
+    );
+
+    if (input.paymentType === "credit" && input.customerId) {
+      await db.execute(
+        "INSERT INTO transactions (customer_id, type, amount, note) VALUES ($1, $2, $3, $4);",
+        [input.customerId, "debt", totalAmount, `Satış #${saleId} - ${itemName}`],
+      );
+    }
+
+    await db.execute("COMMIT;");
+
+    return saleId;
+  } catch (error) {
+    await db.execute("ROLLBACK;");
+    throw error;
   }
-
-  const saleId = saleResult.lastInsertId;
-
-  await db.execute(
-    "INSERT INTO sale_items (sale_id, item_name, quantity, unit_price, total_price) VALUES ($1, $2, $3, $4, $5);",
-    [saleId, itemName, input.quantity, input.unitPrice, totalAmount],
-  );
-
-  if (input.paymentType === "credit" && input.customerId) {
-    await addTransaction({
-      customerId: input.customerId,
-      type: "debt",
-      amount: totalAmount,
-      note: `Satış #${saleId} - ${itemName}`,
-    });
-  }
-
-  return saleId;
 }
 
 export async function getSales(): Promise<Sale[]> {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,6 +3,7 @@ import Database from "@tauri-apps/plugin-sql";
 let dbInstance: Database | null = null;
 
 export type TransactionType = "debt" | "payment";
+export type PaymentType = "cash" | "card" | "credit";
 
 export interface Customer {
   id: number;
@@ -34,6 +35,34 @@ export interface NewTransactionInput {
   note?: string;
 }
 
+export interface Sale {
+  id: number;
+  customer_id: number | null;
+  customer_name: string | null;
+  payment_type: PaymentType;
+  total_amount: number;
+  note: string | null;
+  created_at: string;
+}
+
+export interface SaleItem {
+  id: number;
+  sale_id: number;
+  item_name: string;
+  quantity: number;
+  unit_price: number;
+  total_price: number;
+}
+
+export interface NewSaleInput {
+  customerId?: number;
+  paymentType: PaymentType;
+  note?: string;
+  itemName: string;
+  quantity: number;
+  unitPrice: number;
+}
+
 export interface DashboardSummary {
   totalCustomers: number;
   totalDebt: number;
@@ -54,13 +83,19 @@ function validateTransactionType(type: string): asserts type is TransactionType 
   }
 }
 
-function validateTransactionAmount(amount: number): void {
+function validatePaymentType(type: string): asserts type is PaymentType {
+  if (type !== "cash" && type !== "card" && type !== "credit") {
+    throw new Error("Payment type must be cash, card, or credit.");
+  }
+}
+
+function validatePositiveAmount(amount: number, fieldName: string): void {
   if (!Number.isFinite(amount) || Number.isNaN(amount)) {
-    throw new Error("Transaction amount must be a valid number.");
+    throw new Error(`${fieldName} must be a valid number.`);
   }
 
   if (amount <= 0) {
-    throw new Error("Transaction amount must be greater than 0.");
+    throw new Error(`${fieldName} must be greater than 0.`);
   }
 }
 
@@ -91,12 +126,40 @@ export async function initializeDatabase(): Promise<void> {
     );
   `);
 
+  await db.execute(`
+    CREATE TABLE IF NOT EXISTS sales (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      customer_id INTEGER,
+      payment_type TEXT NOT NULL CHECK(payment_type IN ('cash', 'card', 'credit')),
+      total_amount REAL NOT NULL,
+      note TEXT,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE SET NULL
+    );
+  `);
+
+  await db.execute(`
+    CREATE TABLE IF NOT EXISTS sale_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      sale_id INTEGER NOT NULL,
+      item_name TEXT NOT NULL,
+      quantity REAL NOT NULL,
+      unit_price REAL NOT NULL,
+      total_price REAL NOT NULL,
+      FOREIGN KEY (sale_id) REFERENCES sales(id) ON DELETE CASCADE
+    );
+  `);
+
   await db.execute(
     "CREATE INDEX IF NOT EXISTS idx_transactions_customer_id ON transactions(customer_id);",
   );
 
   await db.execute(
     "CREATE INDEX IF NOT EXISTS idx_customers_name ON customers(name);",
+  );
+
+  await db.execute(
+    "CREATE INDEX IF NOT EXISTS idx_sales_customer_id ON sales(customer_id);",
   );
 }
 
@@ -136,7 +199,7 @@ export async function addTransaction(
   const db = await getDb();
 
   validateTransactionType(input.type);
-  validateTransactionAmount(input.amount);
+  validatePositiveAmount(input.amount, "Transaction amount");
 
   const result = await db.execute(
     "INSERT INTO transactions (customer_id, type, amount, note) VALUES ($1, $2, $3, $4);",
@@ -148,6 +211,82 @@ export async function addTransaction(
   }
 
   return result.lastInsertId;
+}
+
+export async function createSale(input: NewSaleInput): Promise<number> {
+  const db = await getDb();
+
+  validatePaymentType(input.paymentType);
+  validatePositiveAmount(input.quantity, "Quantity");
+  validatePositiveAmount(input.unitPrice, "Unit price");
+
+  const itemName = input.itemName.trim();
+  if (!itemName) {
+    throw new Error("Item name cannot be empty.");
+  }
+
+  if (input.paymentType === "credit" && !input.customerId) {
+    throw new Error("Credit sales require a selected customer.");
+  }
+
+  const totalAmount = input.quantity * input.unitPrice;
+
+  const saleResult = await db.execute(
+    "INSERT INTO sales (customer_id, payment_type, total_amount, note) VALUES ($1, $2, $3, $4);",
+    [input.customerId ?? null, input.paymentType, totalAmount, input.note ?? null],
+  );
+
+  if (saleResult.lastInsertId == null) {
+    throw new Error("Failed to create sale record.");
+  }
+
+  const saleId = saleResult.lastInsertId;
+
+  await db.execute(
+    "INSERT INTO sale_items (sale_id, item_name, quantity, unit_price, total_price) VALUES ($1, $2, $3, $4, $5);",
+    [saleId, itemName, input.quantity, input.unitPrice, totalAmount],
+  );
+
+  if (input.paymentType === "credit" && input.customerId) {
+    await addTransaction({
+      customerId: input.customerId,
+      type: "debt",
+      amount: totalAmount,
+      note: `Satış #${saleId} - ${itemName}`,
+    });
+  }
+
+  return saleId;
+}
+
+export async function getSales(): Promise<Sale[]> {
+  const db = await getDb();
+
+  return db.select<Sale[]>(
+    `SELECT
+      sales.id,
+      sales.customer_id,
+      customers.name AS customer_name,
+      sales.payment_type,
+      sales.total_amount,
+      sales.note,
+      sales.created_at
+     FROM sales
+     LEFT JOIN customers ON customers.id = sales.customer_id
+     ORDER BY sales.created_at DESC;`,
+  );
+}
+
+export async function getSaleItems(saleId: number): Promise<SaleItem[]> {
+  const db = await getDb();
+
+  return db.select<SaleItem[]>(
+    `SELECT id, sale_id, item_name, quantity, unit_price, total_price
+     FROM sale_items
+     WHERE sale_id = $1
+     ORDER BY id ASC;`,
+    [saleId],
+  );
 }
 
 export async function getTransactionsByCustomer(

--- a/src/pages/sales/SalesPage.tsx
+++ b/src/pages/sales/SalesPage.tsx
@@ -1,8 +1,266 @@
-export function SalesPage() {
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  createSale,
+  Customer,
+  getCustomers,
+  getSales,
+  PaymentType,
+  Sale,
+} from "../../db";
+
+type SalesPageProps = {
+  dbReady: boolean;
+  dbError: string | null;
+};
+
+type SalesFormState = {
+  customerId: string;
+  itemName: string;
+  quantity: string;
+  unitPrice: string;
+  paymentType: PaymentType;
+  note: string;
+};
+
+const initialFormState: SalesFormState = {
+  customerId: "",
+  itemName: "",
+  quantity: "1",
+  unitPrice: "",
+  paymentType: "cash",
+  note: "",
+};
+
+function formatAmount(value: number): string {
+  return value.toLocaleString("tr-TR", { style: "currency", currency: "TRY" });
+}
+
+function formatCreatedAt(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString("tr-TR");
+}
+
+function formatPaymentType(value: PaymentType): string {
+  if (value === "cash") return "Nakit";
+  if (value === "card") return "Kart";
+  return "Veresiye";
+}
+
+export function SalesPage({ dbReady, dbError }: SalesPageProps) {
+  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [sales, setSales] = useState<Sale[]>([]);
+  const [formState, setFormState] = useState<SalesFormState>(initialFormState);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const total = useMemo(() => {
+    const quantity = Number(formState.quantity);
+    const unitPrice = Number(formState.unitPrice);
+    if (!Number.isFinite(quantity) || !Number.isFinite(unitPrice)) return 0;
+    if (quantity <= 0 || unitPrice <= 0) return 0;
+    return quantity * unitPrice;
+  }, [formState.quantity, formState.unitPrice]);
+
+  const loadData = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+    try {
+      const [customerRows, saleRows] = await Promise.all([getCustomers(), getSales()]);
+      setCustomers(customerRows);
+      setSales(saleRows);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Satış verileri yüklenemedi.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!dbReady || dbError) return;
+    void loadData();
+  }, [dbReady, dbError, loadData]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const quantity = Number(formState.quantity);
+    const unitPrice = Number(formState.unitPrice);
+
+    if (!formState.itemName.trim()) {
+      setErrorMessage("Ürün/Hizmet adı zorunludur.");
+      return;
+    }
+
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      setErrorMessage("Miktar 0'dan büyük olmalıdır.");
+      return;
+    }
+
+    if (!Number.isFinite(unitPrice) || unitPrice <= 0) {
+      setErrorMessage("Birim fiyat 0'dan büyük olmalıdır.");
+      return;
+    }
+
+    if (formState.paymentType === "credit" && !formState.customerId) {
+      setErrorMessage("Veresiye satış için müşteri seçimi zorunludur.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      await createSale({
+        customerId: formState.customerId ? Number(formState.customerId) : undefined,
+        paymentType: formState.paymentType,
+        note: formState.note.trim() || undefined,
+        itemName: formState.itemName,
+        quantity,
+        unitPrice,
+      });
+
+      setFormState(initialFormState);
+      await loadData();
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Satış kaydedilemedi.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <section className="page">
-      <h1>Sales</h1>
-      <p>Sales slip workflow will be added in upcoming tasks.</p>
+      <h1>Satış Fişi</h1>
+      <p className="status warning">Bu fiş resmi mali belge değildir.</p>
+
+      {dbError && <p className="status error">Veritabanı hatası: {dbError}</p>}
+      {!dbError && !dbReady && <p className="status">Veritabanı hazırlanıyor…</p>}
+
+      <form className="customer-form" onSubmit={handleSubmit}>
+        <label>
+          Müşteri (Opsiyonel)
+          <select
+            value={formState.customerId}
+            onChange={(event) =>
+              setFormState((previous) => ({ ...previous, customerId: event.target.value }))
+            }
+            disabled={!dbReady || !!dbError || isSubmitting}
+          >
+            <option value="">Müşteri seçilmedi</option>
+            {customers.map((customer) => (
+              <option key={customer.id} value={customer.id}>
+                {customer.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Ürün/Hizmet Adı *
+          <input
+            type="text"
+            value={formState.itemName}
+            onChange={(event) =>
+              setFormState((previous) => ({ ...previous, itemName: event.target.value }))
+            }
+            disabled={!dbReady || !!dbError || isSubmitting}
+          />
+        </label>
+
+        <label>
+          Miktar *
+          <input
+            type="number"
+            min="0.01"
+            step="0.01"
+            value={formState.quantity}
+            onChange={(event) =>
+              setFormState((previous) => ({ ...previous, quantity: event.target.value }))
+            }
+            disabled={!dbReady || !!dbError || isSubmitting}
+          />
+        </label>
+
+        <label>
+          Birim Fiyat *
+          <input
+            type="number"
+            min="0.01"
+            step="0.01"
+            value={formState.unitPrice}
+            onChange={(event) =>
+              setFormState((previous) => ({ ...previous, unitPrice: event.target.value }))
+            }
+            disabled={!dbReady || !!dbError || isSubmitting}
+          />
+        </label>
+
+        <label>
+          Ödeme Tipi *
+          <select
+            value={formState.paymentType}
+            onChange={(event) =>
+              setFormState((previous) => ({
+                ...previous,
+                paymentType: event.target.value as PaymentType,
+              }))
+            }
+            disabled={!dbReady || !!dbError || isSubmitting}
+          >
+            <option value="cash">Nakit</option>
+            <option value="card">Kart</option>
+            <option value="credit">Veresiye</option>
+          </select>
+        </label>
+
+        <label>
+          Not
+          <textarea
+            rows={3}
+            value={formState.note}
+            onChange={(event) =>
+              setFormState((previous) => ({ ...previous, note: event.target.value }))
+            }
+            disabled={!dbReady || !!dbError || isSubmitting}
+          />
+        </label>
+
+        <p className="ledger-balance">Toplam: <strong>{formatAmount(total)}</strong></p>
+
+        <button type="submit" disabled={!dbReady || !!dbError || isSubmitting}>
+          {isSubmitting ? "Kaydediliyor..." : "Satış Oluştur"}
+        </button>
+      </form>
+
+      {errorMessage && <p className="status error">{errorMessage}</p>}
+      {isLoading && <p className="status">Satışlar yükleniyor…</p>}
+
+      {sales.length > 0 && (
+        <div className="table-wrap">
+          <table className="customers-table">
+            <thead>
+              <tr>
+                <th>Tarih</th>
+                <th>Müşteri</th>
+                <th>Ödeme Tipi</th>
+                <th>Tutar</th>
+                <th>Not</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sales.map((sale) => (
+                <tr key={sale.id}>
+                  <td>{formatCreatedAt(sale.created_at)}</td>
+                  <td>{sale.customer_name ?? "-"}</td>
+                  <td>{formatPaymentType(sale.payment_type)}</td>
+                  <td>{formatAmount(sale.total_amount)}</td>
+                  <td>{sale.note || "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
### Motivation

- Add a simple local sales workflow so users can create one-item sales slips and review recent sales history stored locally. 
- Ensure credit (`veresiye`) sales create corresponding debt transactions so customer balances remain correct. 
- Keep UI Turkish, show TRY formatting, and surface a visible non-official-document warning.

### Description

- Added `sales` and `sale_items` tables to the local SQLite schema and an index on `sales.customer_id`, plus new TypeScript types for sales models in `src/db`.
- Implemented database functions `createSale(input)`, `getSales()`, and `getSaleItems(saleId)` in `src/db/index.ts`, where `createSale` inserts the sale and the single sale item and validates inputs.
- For `payment_type === "credit"` `createSale` requires a `customerId` and automatically calls existing `addTransaction()` to create a `debt` transaction with a note referencing the sale.
- Implemented the Sales UI in `src/pages/sales/SalesPage.tsx` (Turkish labels) that supports optional customer selection, item name, quantity, unit price, payment type (`Nakit`, `Kart`, `Veresiye`), note, total calculation (TRY / `tr-TR`) and a sales history table, plus the visible warning text `Bu fiş resmi mali belge değildir.` and corresponding CSS styles; wired the page to receive `dbReady`/`dbError` from `App`.

### Testing

- Ran the project build with `npm run build`, which executed TypeScript checks and `vite build`, and it failed because core frontend packages/types (e.g. `react` / `react/jsx-runtime`) are not available in this environment, so the TypeScript/JX compilation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1376323488327b4693dca18dffdd5)