### PR TITLE
feat: add landing and download page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -261,3 +261,80 @@ body {
 .detail-card p {
   margin-top: 0.35rem;
 }
+
+.landing-page {
+  max-width: 900px;
+}
+
+.landing-hero {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.landing-hero p {
+  margin: 0;
+  color: #4b5563;
+}
+
+.download-button {
+  width: fit-content;
+  border: 1px solid #1d4ed8;
+  background: #1d4ed8;
+  color: #ffffff;
+  border-radius: 0.5rem;
+  padding: 0.55rem 0.95rem;
+  font: inherit;
+  opacity: 0.8;
+}
+
+.landing-section {
+  margin-top: 1.5rem;
+}
+
+.landing-section h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+.landing-section ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #374151;
+}
+
+.download-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.download-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.6rem;
+  padding: 0.9rem;
+  background: #fafafa;
+}
+
+.download-card h3,
+.download-card p {
+  margin: 0;
+}
+
+.feedback-link {
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.feedback-link:hover {
+  text-decoration: underline;
+}
+
+.landing-footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+  display: flex;
+  gap: 1rem;
+  color: #4b5563;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { initializeDatabase } from "./db";
 import { CustomersPage } from "./pages/customers/CustomersPage";
 import { DashboardPage } from "./pages/dashboard/DashboardPage";
 import { InventoryPage } from "./pages/inventory/InventoryPage";
+import { LandingPage } from "./pages/landing/LandingPage";
 import { LedgerPage } from "./pages/ledger/LedgerPage";
 import { OrdersPage } from "./pages/orders/OrdersPage";
 import { SalesPage } from "./pages/sales/SalesPage";
@@ -15,6 +16,7 @@ type NavItem = {
 };
 
 const navItems: NavItem[] = [
+  { key: "landing", label: "Landing" },
   { key: "dashboard", label: "Dashboard" },
   { key: "customers", label: "Customers" },
   { key: "ledger", label: "Ledger" },
@@ -25,7 +27,7 @@ const navItems: NavItem[] = [
 ];
 
 export default function App() {
-  const [activePage, setActivePage] = useState<string>("dashboard");
+  const [activePage, setActivePage] = useState<string>("landing");
   const [dbReady, setDbReady] = useState<boolean>(false);
   const [dbError, setDbError] = useState<string | null>(null);
 
@@ -61,6 +63,8 @@ export default function App() {
 
   const pageContent = useMemo(() => {
     switch (activePage) {
+      case "landing":
+        return <LandingPage />;
       case "customers":
         return <CustomersPage dbReady={dbReady} dbError={dbError} />;
       case "ledger":

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,14 +16,14 @@ type NavItem = {
 };
 
 const navItems: NavItem[] = [
-  { key: "landing", label: "Landing" },
-  { key: "dashboard", label: "Dashboard" },
-  { key: "customers", label: "Customers" },
-  { key: "ledger", label: "Ledger" },
-  { key: "sales", label: "Sales" },
-  { key: "orders", label: "Orders" },
-  { key: "inventory", label: "Inventory" },
-  { key: "settings", label: "Settings" },
+  { key: "landing", label: "Tanıtım" },
+  { key: "dashboard", label: "Genel Bakış" },
+  { key: "customers", label: "Müşteriler" },
+  { key: "ledger", label: "Veresiye" },
+  { key: "sales", label: "Satış" },
+  { key: "orders", label: "Siparişler" },
+  { key: "inventory", label: "Stok" },
+  { key: "settings", label: "Ayarlar" },
 ];
 
 export default function App() {

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -1,0 +1,65 @@
+export function LandingPage() {
+  return (
+    <section className="page landing-page">
+      <header className="landing-hero">
+        <h1>EsnafOS</h1>
+        <p>Küçük işletmeler için basit veresiye ve satış yönetimi</p>
+        <button type="button" className="download-button" disabled>
+          İndir (Yakında)
+        </button>
+      </header>
+
+      <section className="landing-section" aria-labelledby="features-title">
+        <h2 id="features-title">Özellikler</h2>
+        <ul>
+          <li>Veresiye takibi</li>
+          <li>Satış kaydı</li>
+          <li>Müşteri yönetimi</li>
+          <li>Kasa özeti</li>
+          <li>Offline çalışma</li>
+        </ul>
+      </section>
+
+      <section className="landing-section" aria-labelledby="about-title">
+        <h2 id="about-title">EsnafOS Nedir?</h2>
+        <p>
+          EsnafOS, küçük işletmeler için geliştirilmiş ücretsiz bir masaüstü
+          uygulamadır.
+        </p>
+      </section>
+
+      <section className="landing-section" aria-labelledby="download-title">
+        <h2 id="download-title">İndirme</h2>
+        <div className="download-grid">
+          <div className="download-card">
+            <h3>Mac</h3>
+            <p>yakında</p>
+          </div>
+          <div className="download-card">
+            <h3>Windows</h3>
+            <p>yakında</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="landing-section" aria-labelledby="cta-title">
+        <h2 id="cta-title">Geri Bildirim</h2>
+        <a
+          href="https://github.com/esnafos/esnafos/issues"
+          target="_blank"
+          rel="noreferrer"
+          className="feedback-link"
+        >
+          Geri bildirim gönder
+        </a>
+      </section>
+
+      <footer className="landing-footer">
+        <a href="https://github.com/esnafos/esnafos" target="_blank" rel="noreferrer">
+          GitHub
+        </a>
+        <span>v0.1.0 (alpha)</span>
+      </footer>
+    </section>
+  );
+}

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -45,7 +45,7 @@ export function LandingPage() {
       <section className="landing-section" aria-labelledby="cta-title">
         <h2 id="cta-title">Geri Bildirim</h2>
         <a
-          href="https://github.com/esnafos/esnafos/issues"
+          href="https://github.com/ilgaraydogan/esnafos/issues"
           target="_blank"
           rel="noreferrer"
           className="feedback-link"
@@ -55,7 +55,7 @@ export function LandingPage() {
       </section>
 
       <footer className="landing-footer">
-        <a href="https://github.com/esnafos/esnafos" target="_blank" rel="noreferrer">
+        <a href="https://github.com/ilgaraydogan/esnafos" target="_blank" rel="noreferrer">
           GitHub
         </a>
         <span>v0.1.0 (alpha)</span>


### PR DESCRIPTION
### Motivation
- Provide a very simple, clean landing page for EsnafOS to introduce the app and surface download placeholders. 
- Offer an easy entry point for users with a short feature list, product description, feedback CTA and version info.

### Description
- Add a new `LandingPage` component at `src/pages/landing/LandingPage.tsx` containing Hero, Features, short explanation, placeholder download cards (Mac/Windows), feedback link to GitHub issues, and footer with `v0.1.0 (alpha)`.
- Wire the landing page into the main navigation by importing `LandingPage` in `src/App.tsx`, adding a `landing` nav item to `navItems`, and making it the default `activePage`.
- Add lightweight styles for the landing and download sections to `src/App.css` following the existing visual language and without external UI libraries.
- All changes are implemented as client-side UI only, with no backend, analytics, or auth added.

### Testing
- Ran `npm run build` which executes `tsc && vite build`, and the build failed due to an unrelated TypeScript dependency/type error: `Cannot find module '@tauri-apps/plugin-dialog'` in `src/pages/settings/SettingsPage.tsx`.
- No other automated tests were run in this PR and the UI changes were not subjected to further CI checks due to the build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f214fc61188327a8fccb02da3e7922)