### PR TITLE
chore: add macOS build workflow

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,44 @@
+name: Build macOS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Build Tauri app (macOS)
+        run: npm run tauri build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: EsnafOS-macOS
+          path: src-tauri/target/release/bundle


### PR DESCRIPTION
### Motivation
- Provide a macOS CI workflow to build the Tauri-based EsnafOS app and produce a distributable bundle for macOS.
- Ensure builds are reproducible on `macos-latest` without adding signing, notarization, or updater configuration at this time.

### Description
- Add a new workflow file at `.github/workflows/build-macos.yml` that triggers on `push` to `main`, `pull_request` to `main`, and `workflow_dispatch`.
- Use the `macos-latest` runner and configure Node 20 via `actions/setup-node@v4` and stable Rust via `dtolnay/rust-toolchain@stable`.
- Implement steps to checkout (`actions/checkout@v4`), run `npm install`, install the Tauri CLI with `cargo install tauri-cli --locked`, run `npm run build`, and run `npm run tauri build` to produce the macOS bundle.
- Upload the produced bundle at `src-tauri/target/release/bundle` as an artifact named `EsnafOS-macOS` using `actions/upload-artifact@v4`, with no signing, notarization, or updater steps added.

### Testing
- Committed the new file successfully via `git commit` with message `chore: add macOS build workflow` and the operation completed without error.
- Verified the workflow file contents by printing the file with `nl -ba .github/workflows/build-macos.yml | sed -n '1,200p'`.
- Checked repository status with `git status --short` to confirm no unexpected changes remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f230822fc48327824e1da3d82d15d6)