### PR TITLE
chore: add macOS GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,39 @@
+name: Build macOS
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Build Tauri app
+        run: npm run tauri build
+
+      - name: Upload macOS bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: EsnafOS-macOS
+          path: src-tauri/target/release/bundle


### PR DESCRIPTION
### Motivation
- Provide a focused GitHub Actions workflow that produces macOS build artifacts so macOS builds can be downloaded from CI. 
- Keep CI minimal and safe by reusing the locally-verified build steps and deliberately avoiding icon generation, signing/notarization, updater, or any app/business-logic changes.

### Description
- Add `.github/workflows/build-macos.yml` that triggers on `push` to `main`, `pull_request` to `main`, and `workflow_dispatch`.
- Configure a `build-macos` job running on `macos-latest` that performs: checkout, Node.js 20 setup, `npm install`, Rust stable setup (via `dtolnay/rust-toolchain@stable`), `npm run build`, and `npm run tauri build`.
- Upload the macOS bundle artifact with name `EsnafOS-macOS` from `src-tauri/target/release/bundle` and do not perform icon generation, signing, notarization, placeholder assets, or other unrelated changes.
- No application or database/source code was modified.

### Testing
- Validated the new workflow file was created and printed with `nl -ba .github/workflows/build-macos.yml` (succeeded).
- Confirmed the workflow path exists via file discovery commands (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4f0ce5fe08327abc16e01942b862c)