### PR TITLE
fix: refresh sales list after save

### DIFF
--- a/src/pages/sales/SalesPage.tsx
+++ b/src/pages/sales/SalesPage.tsx
@@ -27,7 +27,7 @@ type SalesFormState = {
 const initialFormState: SalesFormState = {
   customerId: "",
   itemName: "",
-  quantity: "1",
+  quantity: "",
   unitPrice: "",
   paymentType: "cash",
   note: "",
@@ -55,6 +55,7 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [selectedSaleId, setSelectedSaleId] = useState<number | null>(null);
   const [selectedSaleItem, setSelectedSaleItem] = useState<SaleItem | null>(null);
   const selectedSale = sales.find((sale) => sale.id === selectedSaleId) ?? null;
@@ -67,18 +68,23 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
     return quantity * unitPrice;
   }, [formState.quantity, formState.unitPrice]);
 
+  const refreshSales = useCallback(async () => {
+    const saleRows = await getSales();
+    setSales(saleRows);
+    setSelectedSaleId((previous) =>
+      previous && saleRows.some((sale) => sale.id === previous)
+        ? previous
+        : saleRows[0]?.id ?? null,
+    );
+  }, []);
+
   const loadData = useCallback(async () => {
     setIsLoading(true);
     setErrorMessage(null);
     try {
-      const [customerRows, saleRows] = await Promise.all([getCustomers(), getSales()]);
+      const customerRows = await getCustomers();
       setCustomers(customerRows);
-      setSales(saleRows);
-      setSelectedSaleId((previous) =>
-        previous && saleRows.some((sale) => sale.id === previous)
-          ? previous
-          : saleRows[0]?.id ?? null,
-      );
+      await refreshSales();
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Satış verileri yüklenemedi.");
     } finally {
@@ -129,6 +135,7 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
 
     setIsSubmitting(true);
     setErrorMessage(null);
+    setSuccessMessage(null);
 
     try {
       await createSale({
@@ -141,8 +148,10 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
       });
 
       setFormState(initialFormState);
-      await loadData();
+      await refreshSales();
+      setSuccessMessage("Satış başarıyla kaydedildi.");
     } catch (error) {
+      setSuccessMessage(null);
       setErrorMessage(error instanceof Error ? error.message : "Satış kaydedilemedi.");
     } finally {
       setIsSubmitting(false);
@@ -254,6 +263,7 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
       </form>
 
       {errorMessage && <p className="status error">{errorMessage}</p>}
+      {successMessage && <p className="status">{successMessage}</p>}
       {isLoading && <p className="status">Satış verileri hazırlanıyor…</p>}
 
       {!isLoading && sales.length === 0 && dbReady && !dbError && (


### PR DESCRIPTION
### Motivation
- The sales list did not update in the UI after saving a new sale, requiring a full page refresh to see the new record.  
- The sale form should be cleared after a successful save so the user can start a new entry immediately.  
- Basic user feedback (success / error) was missing around save operations.

### Description
- Modified `src/pages/sales/SalesPage.tsx` to add a dedicated `refreshSales` callback that re-fetches sales via `getSales()` and updates `sales` and `selectedSaleId` so the table reflects new records immediately.  
- Updated `loadData` to fetch customers and call `refreshSales()` rather than fetching sales inline.  
- Reset the sale form on success by calling `setFormState(initialFormState)` and changed the initial `quantity` value to an empty string so all inputs are cleared.  
- Added `successMessage` state and rendering to show a success message after save and ensured `errorMessage` / `successMessage` are cleared appropriately on submit and on error.  
- Changes are frontend-only and confined to `src/pages/sales/SalesPage.tsx`; no database schema or backend logic changes were made.

### Testing
- Ran a production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6041c90e083279e684637a6c61992)