### PR TITLE
chore: make CI manual only

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,10 +1,6 @@
 name: Build macOS
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Motivation
- Convert the macOS CI workflow to run only via manual dispatch to avoid automatic runs on `push` or `pull_request` events.

### Description
- Updated `.github/workflows/build-macos.yml` by replacing the `on:` triggers to only include `workflow_dispatch` and removed the `push` and `pull_request` entries, while leaving all jobs and steps unchanged.

### Testing
- No automated tests were run or required for this trigger-only YAML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60f0ad64c83279b77514490365381)