### PR TITLE
chore: polish dashboard and low stock warnings

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -194,6 +194,10 @@ body {
   background: #eef2ff;
 }
 
+.customers-table tbody tr.low-stock-row {
+  background: #fffbeb;
+}
+
 .customer-form select {
   border: 1px solid #d1d5db;
   border-radius: 0.5rem;

--- a/src/App.css
+++ b/src/App.css
@@ -196,6 +196,17 @@ body {
 
 .customers-table tbody tr.low-stock-row {
   background: #fffbeb;
+  border-left: 3px solid #dc2626;
+}
+
+.low-stock-label {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  color: #b91c1c;
+  background: #fee2e2;
 }
 
 .customer-form select {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ export default function App() {
   const [dbReady, setDbReady] = useState<boolean>(false);
   const [dbError, setDbError] = useState<string | null>(null);
   const [showLowStockWarning, setShowLowStockWarning] = useState(false);
+  const [lowStockWarningShown, setLowStockWarningShown] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -67,7 +68,7 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    if (!dbReady || dbError) return;
+    if (!dbReady || dbError || lowStockWarningShown) return;
 
     let mounted = true;
 
@@ -76,6 +77,7 @@ export default function App() {
         const lowStockProducts = await getLowStockProducts(5);
         if (mounted && lowStockProducts.length > 0) {
           setShowLowStockWarning(true);
+          setLowStockWarningShown(true);
         }
       } catch {
         // Keep warning silent if low-stock check fails.
@@ -87,7 +89,7 @@ export default function App() {
     return () => {
       mounted = false;
     };
-  }, [dbReady, dbError]);
+  }, [dbReady, dbError, lowStockWarningShown]);
 
   const pageContent = useMemo(() => {
     switch (activePage) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
-import { initializeDatabase } from "./db";
+import { getLowStockProducts, initializeDatabase } from "./db";
 import { CustomersPage } from "./pages/customers/CustomersPage";
 import { CashPage } from "./pages/cash/CashPage";
 import { DashboardPage } from "./pages/dashboard/DashboardPage";
@@ -18,7 +18,7 @@ type NavItem = {
 };
 
 const navItems: NavItem[] = [
-  { key: "dashboard", label: "Dashboard" },
+  { key: "dashboard", label: "Genel Bakış" },
   { key: "landing", label: "Tanıtım" },
   { key: "customers", label: "Müşteriler" },
   { key: "ledger", label: "Veresiye" },
@@ -34,6 +34,7 @@ export default function App() {
   const [activePage, setActivePage] = useState<string>("dashboard");
   const [dbReady, setDbReady] = useState<boolean>(false);
   const [dbError, setDbError] = useState<string | null>(null);
+  const [showLowStockWarning, setShowLowStockWarning] = useState(false);
 
   useEffect(() => {
     let mounted = true;
@@ -64,6 +65,29 @@ export default function App() {
       mounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (!dbReady || dbError) return;
+
+    let mounted = true;
+
+    const checkLowStock = async () => {
+      try {
+        const lowStockProducts = await getLowStockProducts(5);
+        if (mounted && lowStockProducts.length > 0) {
+          setShowLowStockWarning(true);
+        }
+      } catch {
+        // Keep warning silent if low-stock check fails.
+      }
+    };
+
+    void checkLowStock();
+
+    return () => {
+      mounted = false;
+    };
+  }, [dbReady, dbError]);
 
   const pageContent = useMemo(() => {
     switch (activePage) {
@@ -116,7 +140,10 @@ export default function App() {
         </nav>
       </aside>
 
-      <main className="content">{pageContent}</main>
+      <main className="content">
+        {showLowStockWarning && <p className="status warning">Düşük stokta ürünler var</p>}
+        {pageContent}
+      </main>
     </div>
   );
 }

--- a/src/pages/inventory/InventoryPage.tsx
+++ b/src/pages/inventory/InventoryPage.tsx
@@ -272,6 +272,7 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
                           }))
                         }
                       />
+                      {isLowStock && <span className="low-stock-label">Düşük stok</span>}
                     </td>
                     <td>
                       <input

--- a/src/pages/inventory/InventoryPage.tsx
+++ b/src/pages/inventory/InventoryPage.tsx
@@ -232,8 +232,9 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
                   stock: String(product.stock),
                   unitPrice: product.unit_price == null ? "" : String(product.unit_price),
                 };
+                const isLowStock = product.stock <= 5;
                 return (
-                  <tr key={product.id}>
+                  <tr key={product.id} className={isLowStock ? "low-stock-row" : undefined}>
                     <td>
                       <input
                         type="text"


### PR DESCRIPTION
### Motivation
- Surface low-stock conditions to the user early without redesigning the UI. 
- Provide a minimal, non-intrusive one-time app-load warning when any product has low stock. 
- Localize the dashboard label to match the app language while keeping existing routing intact.

### Description
- Changed the sidebar label for the existing `dashboard` route key from `Dashboard` to `Genel Bakış` in `src/App.tsx` without altering the route key. 
- Added a one-time app-load low-stock check in `src/App.tsx` that calls `getLowStockProducts(5)` and sets a `showLowStockWarning` flag to render a single message `Düşük stokta ürünler var` when low-stock items exist. 
- Marked inventory rows where `product.stock <= 5` with a `low-stock-row` class in `src/pages/inventory/InventoryPage.tsx`. 
- Added minimal CSS for `.customers-table tbody tr.low-stock-row` in `src/App.css` to lightly highlight low-stock rows. 
- No database schema, sales logic, cash logic, build/workflow changes, or new dependencies were introduced.

### Testing
- Ran `npm run build` (which runs `tsc && vite build`) and it completed successfully. 
- The repository builds cleanly after the changes with no type or bundling errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7898353f483278f42817d847a8653)