### PR TITLE
chore: add Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,41 @@
+name: Build Windows
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: npm install
+        run: npm install
+
+      - name: Build Tauri app
+        run: npm run tauri build
+
+      - name: Upload Windows MSI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: EsnafOS-windows-msi
+          path: src-tauri/target/release/bundle/msi
+
+      - name: Upload Windows NSIS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: EsnafOS-windows-nsis
+          path: src-tauri/target/release/bundle/nsis

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: npm install
-        run: npm install
+      - name: Install Rust target
+        run: rustup target add x86_64-pc-windows-msvc
 
       - name: Build Tauri app
         run: npm run tauri build


### PR DESCRIPTION
### Motivation
- Provide a manual GitHub Actions workflow to build and publish Windows installer bundles so Windows builds (`.msi`/NSIS) can be downloaded from GitHub releases/artifacts.

### Description
- Add `.github/workflows/windows-build.yml` which triggers on `workflow_dispatch`, runs on `windows-latest`, and performs checkout, Node.js 20 setup, Rust setup, `npm install`, `npm run tauri build`, and uploads artifacts from `src-tauri/target/release/bundle/msi` and `src-tauri/target/release/bundle/nsis`.

### Testing
- No CI workflow runs were executed yet; repository commands used to verify the change (`git add`/`git commit` and printing the workflow file) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78b779cf88327970c411bc3097572)