### PR TITLE
fix: resolve product creation failure

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -553,11 +553,16 @@ export async function createProduct(input: NewProductInput): Promise<number> {
     ],
   );
 
-  if (result.lastInsertId == null) {
-    throw new Error("Failed to create product record.");
+  if (result.lastInsertId != null) {
+    return result.lastInsertId;
   }
 
-  return result.lastInsertId;
+  const [row] = await db.select<Array<{ id: number }>>("SELECT last_insert_rowid() AS id;");
+  if (!row?.id) {
+    throw new Error("Failed to create product record: insert id is missing.");
+  }
+
+  return row.id;
 }
 
 export async function getProducts(): Promise<Product[]> {

--- a/src/pages/inventory/InventoryPage.tsx
+++ b/src/pages/inventory/InventoryPage.tsx
@@ -20,6 +20,16 @@ const initialFormState: ProductFormState = {
   unitPrice: "",
 };
 
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return fallback;
+  }
+}
+
 function formatMoney(value: number | null): string {
   if (value == null) return "-";
   return value.toLocaleString("tr-TR", { style: "currency", currency: "TRY" });
@@ -57,7 +67,7 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
         ),
       );
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "Ürünler yüklenemedi.");
+      setErrorMessage(getErrorMessage(error, "Ürünler yüklenemedi."));
     } finally {
       setIsLoading(false);
     }
@@ -103,7 +113,7 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
       setFormState(initialFormState);
       await loadProducts();
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "Ürün kaydedilemedi.");
+      setErrorMessage(getErrorMessage(error, "Ürün kaydedilemedi."));
     } finally {
       setIsSubmitting(false);
     }
@@ -139,7 +149,7 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
       });
       await loadProducts();
     } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : "Ürün güncellenemedi.");
+      setErrorMessage(getErrorMessage(error, "Ürün güncellenemedi."));
     }
   };
 


### PR DESCRIPTION
### Motivation

- Product creation was failing on some platforms where the SQLite driver did not populate `lastInsertId`, causing a generic "Ürün kaydedilemedi" error and preventing products from being saved.
- Error messages in the Inventory UI were masking real database/validation errors with generic text, making debugging and user feedback difficult.

### Description

- Make `createProduct` robust by returning `result.lastInsertId` when available and falling back to `SELECT last_insert_rowid()` to obtain the inserted id, and throw only if no id can be resolved (`src/db/index.ts`).
- Preserve and enforce defensive validation in `createProduct` for `name` (required), `stock` (integer >= 0), and `unitPrice` (number >= 0 when provided) (`src/db/index.ts`).
- Add `getErrorMessage` helper and use it in `InventoryPage` to show the real error message (Error.message, string errors, or JSON-serialized unknown errors) for load/create/update flows instead of a generic message (`src/pages/inventory/InventoryPage.tsx`).
- Keep immediate product list refresh behavior after successful create/update via `await loadProducts()` without any UI redesign or schema changes (`src/pages/inventory/InventoryPage.tsx`).

### Testing

- Ran a production build with `npm run build` which executed `tsc && vite build` and completed successfully.
- Verified that the app compiles and the inventory page code paths for create/update/load were type-checked as part of the build.
- No automated unit tests were added or modified; existing build validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f84f949b3c8327b755fcc428cd0d2d)