### PR TITLE
chore: speed up builds with dependency cache

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,12 +15,20 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
 
       - name: Build frontend
         run: npm run build

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -15,12 +15,20 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install Rust target
         run: rustup target add x86_64-pc-windows-msvc


### PR DESCRIPTION
### Motivation
- Reduce CI build time and improve repeatability by caching Node and Rust/Cargo dependencies in the macOS and Windows build workflows.
- Use faster, deterministic Node installs to avoid variability between runs.
- Keep workflow triggers and application code untouched while optimizing dependency handling.

### Description
- Updated `actions/setup-node@v4` usage to enable Node/npm caching with `cache: npm` and `cache-dependency-path: package-lock.json` in both `.github/workflows/build-macos.yml` and `.github/workflows/windows-build.yml`.
- Replaced `npm install` with `npm ci` in both workflows to perform clean, deterministic installs.
- Added a Rust/Cargo cache step using `Swatinem/rust-cache@v2` in both workflows with `workspaces: src-tauri -> target` and a cache key that includes `src-tauri/Cargo.lock`.
- Preserved `workflow_dispatch` triggers and made no changes to app code, database, or UI files.

### Testing
- No automated unit/integration tests were run as this change only updates CI workflow files; the changes will be validated on the next GitHub Actions runs for the modified workflows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86358bb2083279b769164ce357da8)