### PR TITLE
chore: add UI component foundation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -119,6 +119,44 @@ body[data-theme="dark"] .status.error {
   background: rgba(239, 68, 68, 0.2);
   border-color: rgba(252, 165, 165, 0.38);
 }
+
+.ui-card {
+  border: 1px solid var(--border-soft);
+  background: var(--panel-strong);
+  border-radius: 1.25rem;
+}
+
+.ui-button {
+  border: 1px solid var(--accent-color);
+  border-radius: 0.65rem;
+  padding: 0.58rem 0.95rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.ui-button-default {
+  background: var(--accent-color);
+  color: #fff;
+}
+
+.ui-button-secondary {
+  background: transparent;
+  color: var(--text-main);
+  border-color: var(--border-soft);
+}
+
+.ui-input {
+  border: 1px solid var(--border-soft);
+  background: var(--panel-bg);
+  color: var(--text-main);
+  border-radius: 0.65rem;
+  padding: 0.55rem 0.65rem;
+}
+
+.ui-label {
+  display: grid;
+  gap: 0.35rem;
+}
 .customer-form,.search-input-wrap{ margin-top:1rem; display:grid; gap:.55rem; max-width:520px; }
 .table-wrap { margin-top:1rem; overflow-x:auto; }
 .customers-table { width:100%; border-collapse:collapse; }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import { OrdersPage } from "./pages/orders/OrdersPage";
 import { SalesPage } from "./pages/sales/SalesPage";
 import { SalesHistoryPage } from "./pages/sales-history/SalesHistoryPage";
 import { SettingsPage } from "./pages/settings/SettingsPage";
+import { Button } from "./components/ui/Button";
+import { Card } from "./components/ui/Card";
 
 type NavItem = {
   key: string;
@@ -211,19 +213,19 @@ function Onboarding({ onFinish }: { onFinish: () => void }) {
   const isLastStep = step === steps.length - 1;
 
   return (
-    <section className="page glass-card onboarding-page">
+    <Card className="page glass-card onboarding-page">
       <p className="onboarding-step">Adım {step + 1} / {steps.length}</p>
       <h1>{steps[step].title}</h1>
       <p>{steps[step].text}</p>
 
       <div className="onboarding-actions">
         {step > 0 && (
-          <button type="button" className="secondary" onClick={() => setStep((prev) => prev - 1)}>
+          <Button type="button" variant="secondary" onClick={() => setStep((prev) => prev - 1)}>
             Geri
-          </button>
+          </Button>
         )}
 
-        <button
+        <Button
           type="button"
           onClick={() => {
             if (isLastStep) {
@@ -234,8 +236,8 @@ function Onboarding({ onFinish }: { onFinish: () => void }) {
           }}
         >
           {isLastStep ? "Genel Bakış'a Geç" : "Devam"}
-        </button>
+        </Button>
       </div>
-    </section>
+    </Card>
   );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,12 @@
+import type { ButtonHTMLAttributes } from "react";
+
+type ButtonVariant = "default" | "secondary";
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+};
+
+export function Button({ className = "", variant = "default", ...props }: ButtonProps) {
+  const variantClass = variant === "secondary" ? "ui-button-secondary" : "ui-button-default";
+  return <button className={`ui-button ${variantClass} ${className}`.trim()} {...props} />;
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,7 @@
+import type { HTMLAttributes } from "react";
+
+type CardProps = HTMLAttributes<HTMLElement>;
+
+export function Card({ className = "", ...props }: CardProps) {
+  return <section className={`ui-card ${className}`.trim()} {...props} />;
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,7 @@
+import type { InputHTMLAttributes } from "react";
+
+type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export function Input({ className = "", ...props }: InputProps) {
+  return <input className={`ui-input ${className}`.trim()} {...props} />;
+}

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -1,0 +1,7 @@
+import type { LabelHTMLAttributes } from "react";
+
+type LabelProps = LabelHTMLAttributes<HTMLLabelElement>;
+
+export function Label({ className = "", ...props }: LabelProps) {
+  return <label className={`ui-label ${className}`.trim()} {...props} />;
+}

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { closeDatabase } from "../../db";
+import { Button } from "../../components/ui/Button";
+import { Card } from "../../components/ui/Card";
+import { Input } from "../../components/ui/Input";
+import { Label } from "../../components/ui/Label";
 
 const BUSINESS_NAME_KEY = "esnafos_business_name";
 const THEME_KEY = "esnafos_theme";
@@ -96,14 +100,14 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
   };
 
   return (
-    <section className="page glass-card">
+    <Card className="page glass-card">
       <h1>Ayarlar</h1>
       <p>Uygulama görünümünü ve yerel ayarları buradan yönetebilirsiniz.</p>
 
       <div className="settings-grid">
-        <label>
+        <Label>
           İşletme Adı
-          <input
+          <Input
             value={businessName}
             onChange={(event) => {
               setBusinessName(event.target.value);
@@ -111,7 +115,7 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
             }}
             placeholder="Örn. Yıldız Market"
           />
-        </label>
+        </Label>
 
         <label>
           Tema
@@ -125,7 +129,7 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
           <p>Vurgu Rengi</p>
           <div className="accent-palette">
             {["#4f46e5", "#0284c7", "#059669", "#d97706", "#dc2626"].map((color) => (
-              <button
+              <Button
                 key={color}
                 type="button"
                 aria-label={`Vurgu rengi ${color}`}
@@ -139,15 +143,15 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
       </div>
 
       <div className="settings-actions">
-        <button type="button" onClick={handleBackup}>
+        <Button type="button" onClick={handleBackup}>
           Yedek Al
-        </button>
-        <button type="button" className="secondary" onClick={handleRestore}>
+        </Button>
+        <Button type="button" variant="secondary" onClick={handleRestore}>
           Yedek Yükle
-        </button>
-        <button type="button" className="secondary" onClick={onRestartOnboarding}>
+        </Button>
+        <Button type="button" variant="secondary" onClick={onRestartOnboarding}>
           Onboarding'i Yeniden Göster
-        </button>
+        </Button>
       </div>
 
       <p className="status">Sürüm: v{APP_VERSION}</p>
@@ -157,6 +161,6 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
           {statusMessage}
         </p>
       )}
-    </section>
+    </Card>
   );
 }


### PR DESCRIPTION
### Motivation
- Introduce a minimal internal UI component layer to prepare the app for a more polished component system while preserving existing visuals and workflows. 
- Keep the implementation lightweight and local (no heavy UI frameworks) and reuse existing CSS variables to maintain the glass/visionOS-like style. 
- Apply the new layer in a very limited, safe scope so business logic, database, and core workflows remain unchanged.

### Description
- Added lightweight foundation components under `src/components/ui/`: `Button`, `Card`, `Input`, and `Label` as simple wrappers with predictable CSS classes. 
- Added shared UI utility styles in `src/App.css` (`.ui-card`, `.ui-button`, `.ui-input`, `.ui-label`) that reuse existing theme and accent CSS variables. 
- Replaced a small, safe set of usages to start adopting the component layer without changing behavior: `SettingsPage` now uses `Card`, `Label`, `Input`, and `Button` for the business-name field, accent swatches, and action buttons, and `Onboarding` in `src/App.tsx` uses `Card` and `Button` for its layout and actions. 
- No new runtime dependencies were introduced and no business/database/workflow code was modified.

### Testing
- Ran `npm run build` (`tsc && vite build`) locally to validate the TypeScript build. 
- Build failed due to an existing project dependency issue (`Cannot find module 'framer-motion'`) unrelated to the added components, so the new components themselves do not cause the failure. 
- No other automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1878f3a883279fb151440df1d377)