### PR TITLE
chore: add UI component foundation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -157,3 +157,27 @@ body[data-theme="dark"] .status.error {
   color: #b91c1c;
   background: #fee2e2;
 }
+
+.ui-button {
+  border: 1px solid var(--accent-color);
+  background: var(--accent-color);
+  color: #fff;
+  padding: 0.58rem 0.95rem;
+  border-radius: 0.65rem;
+  cursor: pointer;
+}
+.ui-button.secondary { background: transparent; color: var(--text-main); border-color: var(--border-soft); }
+.ui-input {
+  border: 1px solid var(--border-soft);
+  background: var(--panel-bg);
+  color: var(--text-main);
+  border-radius: 0.65rem;
+  padding: 0.55rem 0.65rem;
+}
+.ui-label { display: grid; gap: 0.35rem; }
+.ui-card {
+  background: var(--panel-strong);
+  border: 1px solid var(--border-soft);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { OrdersPage } from "./pages/orders/OrdersPage";
 import { SalesPage } from "./pages/sales/SalesPage";
 import { SalesHistoryPage } from "./pages/sales-history/SalesHistoryPage";
 import { SettingsPage } from "./pages/settings/SettingsPage";
+import { Button, Card } from "./components/ui";
 
 type NavItem = {
   key: string;
@@ -211,19 +212,19 @@ function Onboarding({ onFinish }: { onFinish: () => void }) {
   const isLastStep = step === steps.length - 1;
 
   return (
-    <section className="page glass-card onboarding-page">
+    <Card className="page glass-card onboarding-page">
       <p className="onboarding-step">Adım {step + 1} / {steps.length}</p>
       <h1>{steps[step].title}</h1>
       <p>{steps[step].text}</p>
 
       <div className="onboarding-actions">
         {step > 0 && (
-          <button type="button" className="secondary" onClick={() => setStep((prev) => prev - 1)}>
+          <Button type="button" variant="secondary" onClick={() => setStep((prev) => prev - 1)}>
             Geri
-          </button>
+          </Button>
         )}
 
-        <button
+        <Button
           type="button"
           onClick={() => {
             if (isLastStep) {
@@ -234,8 +235,8 @@ function Onboarding({ onFinish }: { onFinish: () => void }) {
           }}
         >
           {isLastStep ? "Genel Bakış'a Geç" : "Devam"}
-        </button>
+        </Button>
       </div>
-    </section>
+    </Card>
   );
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,20 @@
+import type { ButtonHTMLAttributes, PropsWithChildren } from "react";
+
+type ButtonVariant = "primary" | "secondary";
+
+type ButtonProps = PropsWithChildren<
+  ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: ButtonVariant;
+  }
+>;
+
+export function Button({ variant = "primary", className = "", children, ...props }: ButtonProps) {
+  const variantClassName = variant === "secondary" ? "secondary" : "";
+  const composedClassName = ["ui-button", variantClassName, className].filter(Boolean).join(" ");
+
+  return (
+    <button {...props} className={composedClassName}>
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,13 @@
+import type { HTMLAttributes, PropsWithChildren } from "react";
+
+type CardProps = PropsWithChildren<HTMLAttributes<HTMLElement>>;
+
+export function Card({ className = "", children, ...props }: CardProps) {
+  const composedClassName = ["ui-card", className].filter(Boolean).join(" ");
+
+  return (
+    <section {...props} className={composedClassName}>
+      {children}
+    </section>
+  );
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,9 @@
+import type { InputHTMLAttributes } from "react";
+
+type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export function Input({ className = "", ...props }: InputProps) {
+  const composedClassName = ["ui-input", className].filter(Boolean).join(" ");
+
+  return <input {...props} className={composedClassName} />;
+}

--- a/src/components/ui/Label.tsx
+++ b/src/components/ui/Label.tsx
@@ -1,0 +1,13 @@
+import type { LabelHTMLAttributes, PropsWithChildren } from "react";
+
+type LabelProps = PropsWithChildren<LabelHTMLAttributes<HTMLLabelElement>>;
+
+export function Label({ className = "", children, ...props }: LabelProps) {
+  const composedClassName = ["ui-label", className].filter(Boolean).join(" ");
+
+  return (
+    <label {...props} className={composedClassName}>
+      {children}
+    </label>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,4 @@
+export { Button } from "./Button";
+export { Card } from "./Card";
+export { Input } from "./Input";
+export { Label } from "./Label";

--- a/src/pages/settings/SettingsPage.tsx
+++ b/src/pages/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { closeDatabase } from "../../db";
+import { Button, Card, Input, Label } from "../../components/ui";
 
 const BUSINESS_NAME_KEY = "esnafos_business_name";
 const THEME_KEY = "esnafos_theme";
@@ -96,14 +97,14 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
   };
 
   return (
-    <section className="page glass-card">
+    <Card className="page glass-card">
       <h1>Ayarlar</h1>
       <p>Uygulama görünümünü ve yerel ayarları buradan yönetebilirsiniz.</p>
 
       <div className="settings-grid">
-        <label>
+        <Label>
           İşletme Adı
-          <input
+          <Input
             value={businessName}
             onChange={(event) => {
               setBusinessName(event.target.value);
@@ -111,7 +112,7 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
             }}
             placeholder="Örn. Yıldız Market"
           />
-        </label>
+        </Label>
 
         <label>
           Tema
@@ -125,7 +126,7 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
           <p>Vurgu Rengi</p>
           <div className="accent-palette">
             {["#4f46e5", "#0284c7", "#059669", "#d97706", "#dc2626"].map((color) => (
-              <button
+              <Button
                 key={color}
                 type="button"
                 aria-label={`Vurgu rengi ${color}`}
@@ -139,15 +140,15 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
       </div>
 
       <div className="settings-actions">
-        <button type="button" onClick={handleBackup}>
+        <Button type="button" onClick={handleBackup}>
           Yedek Al
-        </button>
-        <button type="button" className="secondary" onClick={handleRestore}>
+        </Button>
+        <Button type="button" variant="secondary" onClick={handleRestore}>
           Yedek Yükle
-        </button>
-        <button type="button" className="secondary" onClick={onRestartOnboarding}>
+        </Button>
+        <Button type="button" variant="secondary" onClick={onRestartOnboarding}>
           Onboarding'i Yeniden Göster
-        </button>
+        </Button>
       </div>
 
       <p className="status">Sürüm: v{APP_VERSION}</p>
@@ -157,6 +158,6 @@ export function SettingsPage({ onRestartOnboarding }: SettingsPageProps) {
           {statusMessage}
         </p>
       )}
-    </section>
+    </Card>
   );
 }


### PR DESCRIPTION
### Motivation

- Introduce a minimal internal UI component layer to centralize small reusable primitives without changing app behavior. 
- Keep visuals consistent by reusing existing CSS variables from `App.css` and avoid a full redesign. 
- Restrict replacements to safe locations (onboarding and settings) so workflows, database, and business logic remain untouched. 

### Description

- Add lightweight components `Button`, `Card`, `Input`, and `Label` under `src/components/ui/` and a barrel export at `src/components/ui/index.ts`. 
- Add small utility CSS classes (`.ui-button`, `.ui-input`, `.ui-label`, `.ui-card`) to `src/App.css` that reuse existing CSS variables and tokens. 
- Replace safe usages only: onboarding container and action buttons were switched to `Card`/`Button`, and settings page container, business name `Label`/`Input`, accent swatches, and action buttons were switched to the new components, with imports updated accordingly. 
- No database schema, backend, sales/inventory/cash logic, workflows, or external dependencies were intentionally changed as part of this change. 

### Testing

- Ran `npm run build` (TypeScript + Vite) which initially failed due to a missing module/type for `framer-motion` (TS2307). 
- Ran `npm install` to restore required packages and then re-ran `npm run build`, and the build completed successfully (TypeScript compilation and Vite produced `dist/`). 
- No automated tests beyond the build steps were added or modified, and the build result passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb19ad78f48327833ac68c1d70f7b7)