### PR TITLE
feat: apply UI polish across main pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -181,3 +181,13 @@ body[data-theme="dark"] .status.error {
   border-radius: 1.25rem;
   padding: 1.5rem;
 }
+
+.page-header { margin-bottom: 1rem; }
+.page-header p { margin: 0.35rem 0 0; }
+.page-grid { display: grid; gap: 1rem; }
+.glass-section { background: var(--panel-bg); border: 1px solid var(--border-soft); border-radius: 1rem; padding: 1rem; }
+.table-clean th { font-weight: 600; color: var(--text-muted); }
+.table-clean td,.table-clean th { padding: 0.7rem 0.6rem; }
+.empty-state { border: 1px dashed var(--border-soft); border-radius: 0.9rem; padding: 1rem; color: var(--text-muted); background: var(--panel-bg); }
+.form-actions { display: flex; gap: 0.6rem; margin-top: 0.35rem; }
+.field-grid { display: grid; gap: 0.7rem; }

--- a/src/pages/cash/CashPage.tsx
+++ b/src/pages/cash/CashPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import { addCashEntry, CashEntry, CashEntryType, getCashEntries, getTotalCashBalance } from "../../db";
+import { Button, Card, Input, Label } from "../../components/ui";
 
 type CashPageProps = {
   dbReady: boolean;
@@ -80,7 +81,7 @@ export function CashPage({ dbReady, dbError }: CashPageProps) {
   };
 
   return (
-    <section className="page">
+    <section className="page page-grid">
       <h1>Kasa</h1>
       <p className="ledger-balance">Toplam Bakiye: <strong>{formatAmount(totalBalance)}</strong></p>
 
@@ -89,8 +90,8 @@ export function CashPage({ dbReady, dbError }: CashPageProps) {
       {errorMessage && <p className="status error">{errorMessage}</p>}
       {successMessage && <p className="status success">{successMessage}</p>}
 
-      <form className="customer-form" onSubmit={handleSubmit}>
-        <label>
+      <Card className="glass-card"><form className="customer-form field-grid" onSubmit={handleSubmit}>
+        <Label>
           Tür
           <select
             value={formState.type}
@@ -102,11 +103,11 @@ export function CashPage({ dbReady, dbError }: CashPageProps) {
             <option value="income">Gelir</option>
             <option value="expense">Gider</option>
           </select>
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Tutar *
-          <input
+          <Input
             type="number"
             min="0.01"
             step="0.01"
@@ -114,9 +115,9 @@ export function CashPage({ dbReady, dbError }: CashPageProps) {
             onChange={(event) => setFormState((previous) => ({ ...previous, amount: event.target.value }))}
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Not
           <textarea
             rows={3}
@@ -124,14 +125,14 @@ export function CashPage({ dbReady, dbError }: CashPageProps) {
             onChange={(event) => setFormState((previous) => ({ ...previous, note: event.target.value }))}
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <button type="submit" disabled={!dbReady || !!dbError || isSubmitting}>
+        <Button type="submit" disabled={!dbReady || !!dbError || isSubmitting}>
           {isSubmitting ? "Kaydediliyor..." : "Kasa Hareketi Ekle"}
-        </button>
-      </form>
+        </Button>
+      </form></Card>
 
-      <section className="panel">
+      <Card className="glass-card">
         <h2>Kasa Hareketleri</h2>
         {entries.length === 0 ? (
           <p>Henüz kasa hareketi yok.</p>
@@ -147,7 +148,7 @@ export function CashPage({ dbReady, dbError }: CashPageProps) {
             ))}
           </ul>
         )}
-      </section>
+      </Card>
     </section>
   );
 }

--- a/src/pages/customers/CustomersPage.tsx
+++ b/src/pages/customers/CustomersPage.tsx
@@ -4,6 +4,7 @@ import {
   Customer,
   getCustomers,
 } from "../../db";
+import { Button, Card, Input, Label } from "../../components/ui";
 
 type CustomersPageProps = {
   dbReady: boolean;
@@ -105,16 +106,16 @@ export function CustomersPage({ dbReady, dbError }: CustomersPageProps) {
   });
 
   return (
-    <section className="page">
-      <h1>Müşteriler</h1>
+    <section className="page page-grid">
+      <header className="page-header"><h1>Müşteriler</h1><p>Müşteri listenizi yönetin ve hızlıca arayın.</p></header>
 
       {dbError && <p className="status error">Veritabanı hatası: {dbError}</p>}
       {!dbError && !dbReady && <p className="status">Veritabanı hazırlanıyor…</p>}
 
-      <form className="customer-form" onSubmit={handleSubmit}>
-        <label>
+      <Card className="glass-card"><form className="customer-form field-grid" onSubmit={handleSubmit}>
+        <Label>
           Ad Soyad *
-          <input
+          <Input
             type="text"
             value={formState.name}
             onChange={(event) =>
@@ -126,11 +127,11 @@ export function CustomersPage({ dbReady, dbError }: CustomersPageProps) {
             required
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Telefon
-          <input
+          <Input
             type="text"
             value={formState.phone}
             onChange={(event) =>
@@ -141,9 +142,9 @@ export function CustomersPage({ dbReady, dbError }: CustomersPageProps) {
             }
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Not
           <textarea
             rows={3}
@@ -156,26 +157,26 @@ export function CustomersPage({ dbReady, dbError }: CustomersPageProps) {
             }
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <button
+        <Button
           type="submit"
           disabled={!dbReady || !!dbError || isSubmitting}
         >
           {isSubmitting ? "Kaydediliyor..." : "Müşteri Ekle"}
-        </button>
-      </form>
+        </Button>
+      </form></Card>
 
-      <label className="search-input-wrap">
+      <Card className="glass-card"><Label className="search-input-wrap">
         Müşteri Ara
-        <input
+        <Input
           type="text"
           placeholder="Ad veya telefon ile ara"
           value={searchText}
           onChange={(event) => setSearchText(event.target.value)}
           disabled={!dbReady || !!dbError || isLoading}
         />
-      </label>
+      </Label></Card>
 
       {errorMessage && <p className="status error">{errorMessage}</p>}
       {isLoading && <p className="status">Müşteriler hazırlanıyor, lütfen bekleyin…</p>}
@@ -190,7 +191,7 @@ export function CustomersPage({ dbReady, dbError }: CustomersPageProps) {
 
       {filteredCustomers.length > 0 && (
         <div className="table-wrap">
-          <table className="customers-table">
+          <table className="customers-table table-clean">
             <thead>
               <tr>
                 <th>Ad Soyad</th>

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -5,6 +5,7 @@ import {
   getTodaySalesTotal,
   type LowStockProduct,
 } from "../../db";
+import { Card } from "../../components/ui";
 
 type DashboardPageProps = {
   dbReady: boolean;
@@ -69,7 +70,7 @@ export function DashboardPage({ dbReady, dbError }: DashboardPageProps) {
   }, [dbError, dbReady]);
 
   return (
-    <section className="page">
+    <section className="page page-grid">
       <h1>Dashboard</h1>
       <p>Günlük özet.</p>
 
@@ -81,22 +82,22 @@ export function DashboardPage({ dbReady, dbError }: DashboardPageProps) {
       {dbReady && !dbError && !loading && !error && (
         <>
           <div className="dashboard-cards" aria-label="Dashboard günlük özet kartları">
-            <article className="summary-card">
+            <Card className="summary-card glass-card">
               <h2>Bugünkü Toplam Satış</h2>
               <p>{moneyFormatter.format(todaySalesTotal)}</p>
-            </article>
+            </Card>
 
-            <article className="summary-card">
+            <Card className="summary-card glass-card">
               <h2>Bugünkü Satış Sayısı</h2>
               <p>{todaySalesCount}</p>
-            </article>
+            </Card>
           </div>
 
           <h2>Düşük Stok Ürünleri</h2>
           {lowStockProducts.length === 0 ? (
             <p>Düşük stokta ürün yok.</p>
           ) : (
-            <div className="card" style={{ marginTop: "0.75rem" }}>
+            <Card className="glass-card" style={{ marginTop: "0.75rem" }}>
               <table>
                 <thead>
                   <tr>
@@ -113,7 +114,7 @@ export function DashboardPage({ dbReady, dbError }: DashboardPageProps) {
                   ))}
                 </tbody>
               </table>
-            </div>
+            </Card>
           )}
         </>
       )}

--- a/src/pages/inventory/InventoryPage.tsx
+++ b/src/pages/inventory/InventoryPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useCallback, useEffect, useState } from "react";
 import { createProduct, getProducts, Product, updateProduct } from "../../db";
+import { Button, Card, Input, Label } from "../../components/ui";
 
 type InventoryPageProps = {
   dbReady: boolean;
@@ -154,17 +155,17 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
   };
 
   return (
-    <section className="page">
+    <section className="page page-grid">
       <h1>Stok Yönetimi</h1>
       <p>Ürünlerinizi ekleyin ve düşük stokları takip edin.</p>
 
       {dbError && <p className="status error">Veritabanı hatası: {dbError}</p>}
       {!dbError && !dbReady && <p className="status">Veritabanı hazırlanıyor…</p>}
 
-      <form className="customer-form" onSubmit={handleSubmit}>
-        <label>
+      <Card className="glass-card"><form className="customer-form field-grid" onSubmit={handleSubmit}>
+        <Label>
           Ürün Adı *
-          <input
+          <Input
             type="text"
             value={formState.name}
             onChange={(event) =>
@@ -172,11 +173,11 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
             }
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           SKU
-          <input
+          <Input
             type="text"
             value={formState.sku}
             onChange={(event) =>
@@ -184,11 +185,11 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
             }
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Stok Adedi *
-          <input
+          <Input
             type="number"
             min="0"
             step="1"
@@ -198,11 +199,11 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
             }
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Birim Fiyat (₺)
-          <input
+          <Input
             type="number"
             min="0"
             step="0.01"
@@ -212,19 +213,19 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
             }
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <button type="submit" disabled={!dbReady || !!dbError || isSubmitting}>
+        <Button type="submit" disabled={!dbReady || !!dbError || isSubmitting}>
           {isSubmitting ? "Kaydediliyor..." : "Ürün Ekle"}
-        </button>
-      </form>
+        </Button>
+      </form></Card>
 
       {errorMessage && <p className="status error">{errorMessage}</p>}
       {isLoading && <p className="status">Ürünler yükleniyor…</p>}
 
       {products.length > 0 && (
         <div className="table-wrap">
-          <table className="customers-table">
+          <table className="customers-table table-clean">
             <thead>
               <tr>
                 <th>Ürün</th>
@@ -246,7 +247,7 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
                 return (
                   <tr key={product.id} className={isLowStock ? "low-stock-row" : undefined}>
                     <td>
-                      <input
+                      <Input
                         type="text"
                         value={productInput.name}
                         onChange={(event) =>
@@ -258,7 +259,7 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
                       />
                     </td>
                     <td>
-                      <input
+                      <Input
                         type="text"
                         value={productInput.sku}
                         onChange={(event) =>
@@ -270,7 +271,7 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
                       />
                     </td>
                     <td>
-                      <input
+                      <Input
                         type="number"
                         min="0"
                         step="1"
@@ -285,7 +286,7 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
                       {isLowStock && <span className="low-stock-label">Düşük stok</span>}
                     </td>
                     <td>
-                      <input
+                      <Input
                         type="number"
                         min="0"
                         step="0.01"
@@ -300,9 +301,9 @@ export function InventoryPage({ dbReady, dbError }: InventoryPageProps) {
                       />
                     </td>
                     <td>
-                      <button type="button" onClick={() => void handleProductUpdate(product.id)}>
+                      <Button type="button" onClick={() => void handleProductUpdate(product.id)}>
                         Güncelle
-                      </button>
+                      </Button>
                     </td>
                   </tr>
                 );

--- a/src/pages/sales-history/SalesHistoryPage.tsx
+++ b/src/pages/sales-history/SalesHistoryPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { getAllSales, getSaleById, SaleHistoryItem } from "../../db";
+import { Card } from "../../components/ui";
 
 type SalesHistoryPageProps = {
   dbReady: boolean;
@@ -69,7 +70,7 @@ export function SalesHistoryPage({ dbReady, dbError }: SalesHistoryPageProps) {
   };
 
   return (
-    <section className="page">
+    <section className="page page-grid">
       <h1>Satış Geçmişi</h1>
       {dbError && <p className="status error">Veritabanı hatası: {dbError}</p>}
       {!dbError && !dbReady && <p className="status">Veritabanı hazırlanıyor…</p>}
@@ -82,7 +83,7 @@ export function SalesHistoryPage({ dbReady, dbError }: SalesHistoryPageProps) {
 
       {sales.length > 0 && (
         <div className="table-wrap">
-          <table className="customers-table">
+          <table className="customers-table table-clean">
             <thead>
               <tr>
                 <th>Ürün</th>
@@ -106,14 +107,14 @@ export function SalesHistoryPage({ dbReady, dbError }: SalesHistoryPageProps) {
       )}
 
       {selectedSale && (
-        <section className="detail-card">
+        <Card className="detail-card glass-card">
           <h2>Fiş Detayı</h2>
           <p><strong>Ürün:</strong> {selectedSale.product_name}</p>
           <p><strong>Miktar:</strong> {selectedSale.quantity}</p>
           <p><strong>Birim Fiyat:</strong> {formatAmount(selectedSale.unit_price)}</p>
           <p><strong>Toplam:</strong> {formatAmount(selectedSale.total)}</p>
           <p><strong>Tarih:</strong> {formatCreatedAt(selectedSale.created_at)}</p>
-        </section>
+        </Card>
       )}
     </section>
   );

--- a/src/pages/sales/SalesPage.tsx
+++ b/src/pages/sales/SalesPage.tsx
@@ -11,6 +11,7 @@ import {
   Sale,
   SaleItem,
 } from "../../db";
+import { Button, Card, Input, Label } from "../../components/ui";
 
 type SalesPageProps = {
   dbReady: boolean;
@@ -167,15 +168,15 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
   };
 
   return (
-    <section className="page">
+    <section className="page page-grid">
       <h1>Satış Fişi</h1>
       <p className="status warning">Bu fiş resmi mali belge değildir.</p>
 
       {dbError && <p className="status error">Veritabanı hatası: {dbError}</p>}
       {!dbError && !dbReady && <p className="status">Veritabanı hazırlanıyor…</p>}
 
-      <form className="customer-form" onSubmit={handleSubmit}>
-        <label>
+      <Card className="glass-card"><form className="customer-form field-grid" onSubmit={handleSubmit}>
+        <Label>
           Müşteri (Opsiyonel)
           <select
             value={formState.customerId}
@@ -191,9 +192,9 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
               </option>
             ))}
           </select>
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Ürün *
           <select
             value={formState.productId}
@@ -209,11 +210,11 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
               </option>
             ))}
           </select>
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Miktar *
-          <input
+          <Input
             type="number"
             min="1"
             step="1"
@@ -223,9 +224,9 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
             }
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Ödeme Tipi *
           <select
             value={formState.paymentType}
@@ -241,9 +242,9 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
             <option value="card">Kart</option>
             <option value="credit">Veresiye</option>
           </select>
-        </label>
+        </Label>
 
-        <label>
+        <Label>
           Not
           <textarea
             rows={3}
@@ -253,14 +254,14 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
             }
             disabled={!dbReady || !!dbError || isSubmitting}
           />
-        </label>
+        </Label>
 
         <p className="ledger-balance">Toplam: <strong>{formatAmount(total)}</strong></p>
 
-        <button type="submit" disabled={!dbReady || !!dbError || isSubmitting}>
+        <Button type="submit" disabled={!dbReady || !!dbError || isSubmitting}>
           {isSubmitting ? "Kaydediliyor..." : "Satış Oluştur"}
-        </button>
-      </form>
+        </Button>
+      </form></Card>
 
       {errorMessage && <p className="status error">{errorMessage}</p>}
       {successMessage && <p className="status">{successMessage}</p>}
@@ -272,7 +273,7 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
 
       {sales.length > 0 && (
         <div className="table-wrap">
-          <table className="customers-table">
+          <table className="customers-table table-clean">
             <thead>
               <tr>
                 <th>Tarih</th>
@@ -302,7 +303,7 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
       )}
 
       {selectedSale && (
-        <section className="detail-card">
+        <Card className="detail-card glass-card">
           <h2>Satış Detayı</h2>
           <p><strong>Ürün/Hizmet:</strong> {selectedSaleItem?.item_name ?? "-"}</p>
           <p><strong>Miktar:</strong> {selectedSaleItem?.quantity ?? "-"}</p>
@@ -312,7 +313,7 @@ export function SalesPage({ dbReady, dbError }: SalesPageProps) {
           <p><strong>Müşteri:</strong> {selectedSale.customer_name ?? "-"}</p>
           <p><strong>Not:</strong> {selectedSale.note || "-"}</p>
           <p><strong>Tarih:</strong> {formatCreatedAt(selectedSale.created_at)}</p>
-        </section>
+        </Card>
       )}
     </section>
   );


### PR DESCRIPTION
### Motivation
- Bring the app in line with the shared `src/components/ui` foundation so pages use consistent Card/Button/Input/Label primitives for UI coherence.
- Improve visual hierarchy and spacing on primary screens (Dashboard, Inventory, Sales, Sales History, Cash, Customers) using glass-style cards and cleaner table/empty-state treatments.
- Keep business logic, data model, and workflows unchanged while modernizing the presentation layer.

### Description
- Replaced native form controls and local card/section markup with shared components by importing and using `Card`, `Button`, `Input`, and `Label` in the affected pages (`DashboardPage`, `InventoryPage`, `SalesPage`, `SalesHistoryPage`, `CashPage`, `CustomersPage`).
- Wrapped forms and detail sections in `Card` with the `glass-card` class, converted tables to use the `table-clean` styling, and adjusted layout to a `.page-grid` rhythm for consistent spacing.
- Added small global style utilities in `src/App.css` (`.page-header`, `.page-grid`, `.table-clean`, `.empty-state`, `.field-grid`, etc.) and retained existing visionOS/glass CSS variables and tokens.
- Preserved all business logic and database interactions; no DB schema changes, no new dependencies, and no workflow or feature additions (categories/variants/customer custom fields were not added).

### Testing
- Ran a full production build with `npm run build` which completed successfully (TypeScript compilation and `vite build` pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1b88aad08327b08b974c51d08817)